### PR TITLE
Remove auth token on pickle

### DIFF
--- a/gcsfs/tests/recordings/test_map_pickle.yaml
+++ b/gcsfs/tests/recordings/test_map_pickle.yaml
@@ -12,14 +12,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAK/WuVgC/6tWSq0oyCxKLY7PzFOyUjA2MzDQUVDKTIkvyc9OBYkoVVRUKAGFwPz4ksqCVJCg
-        U2piUWoRSDwxOTm1uBhVeS0A03RPm1YAAAA=
+        H4sIAD01yFgC/6tWSkxOTi0uji/Jz07NU7JSUKqoqFDSUVAC8+NLKgtSQYJOqYlFqUUg8dSKgsyi
+        1OL4TJBiYzMDA6BYZgqq9loA0rtzTlYAAAA=
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:47 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:57 GMT']
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [GSE]
@@ -71,15 +71,15 @@ interactions:
         \  \"metageneration\": \"1\",\n   \"location\": \"US\",\n   \"storageClass\":
         \"STANDARD\",\n   \"etag\": \"CAE=\"\n  }\n ]\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0, must-revalidate, no-transform']
       Content-Length: ['2440']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:48 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:48 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:58 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:58 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uq0DOhgpcIZ9sxdDCUWgsDk-sDfG2izG98Y9qf-ejy2_5viWHCVUAPFk0DpU21g-mxGUREGC0WObuSbYJog3W-IYXpeDg]
+      X-GUploader-UploadID: [AEnB2UrNQqer8WNeNPrajsYJQRT4_knRNi62TQ0bm8ax1UTLCgjPMzSUaQoX9i6gM17KSxRWT2-uut5BY1nEVZekGhsIWW898Q]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -96,15 +96,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:48 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:48 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:58 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:58 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Up3ITpXyk6kxaW8DkHvKOfobI1f8Pfm_gCf-eryzRXu047X6YcBzmbMW2SP6LsCTS_nMI4W4JEXqpnVCuWO2FNlTNKAuw]
+      X-GUploader-UploadID: [AEnB2Urhm1WY4UlrvJ1e7Hzu3_Wiw6x51b-3UPoX60gCI1PTjew5-c_vXF4-_VHxPGM_3S8gues-BtiEQzCUujdABGxwfAQo2g]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -121,15 +121,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:48 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:48 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:58 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:58 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UoKKDBJLh6Cj5WxmTD8xHHLWQ1MJLadq34UExjcBnjhPZ9zrP1x1VFYLEh_sX_YjXh4cw1s2V856obO-rjjnv99caXH3Q]
+      X-GUploader-UploadID: [AEnB2Ur6uwTXs5Rard4ZiuXFSE2pAz1TY6m_xDpawp5zVPRCtjLqMDZk1YG40Vo2zV_bDKr64iK8oe75kgmk0Yy-1I96o-KmPw]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -146,15 +146,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:49 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:49 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:58 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:58 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UrbbixqLFqkZpM0PISr2tGLA5ou6GRMEayi75p81W-BZr2EdmGCeM6V9Xt_MArRz8ZbYYPWPfht0ll_uN8lSC3eRq9Vhw]
+      X-GUploader-UploadID: [AEnB2Up8aJMPL7YsAgCnuKY2evVYFV_o7d-OaAImQX2NbthrDMxzVs_BUSNoSBs3Xhhl0aiuJQhnZHqkhkycInYnfgxVVzO_ow]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -171,15 +171,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:49 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:49 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:58 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:58 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UrJD8_L_1RhGy9IT0As_gr89Ww-zGoX-4Bpt0lxkf7S0o17kJ1FT_dY9QlLXYbHdeNIqS97nYjh3CB2XL6mr6sNrp-iEg]
+      X-GUploader-UploadID: [AEnB2UqD-wKs43f1eYBzlve4fOg5jtH7I1_r8vKdYiuew1xPAFO2VRv1DQYSqP8XQdky1aOvDTLogNJyhYS1wRagNZl8ASnNQQ]
     status: {code: 404, message: Not Found}
 - request:
     body: '1'
@@ -192,26 +192,26 @@ interactions:
     method: POST
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?name=mapping%2Fx&uploadType=media
   response:
-    body: {string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/mapping/x/1488574129510430\",\n
+    body: {string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/mapping/x/1489515839025596\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/mapping%2Fx\",\n
         \"name\": \"mapping/x\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1488574129510430\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2017-03-03T20:48:49.489Z\",\n
-        \"updated\": \"2017-03-03T20:48:49.489Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2017-03-03T20:48:49.489Z\",\n \"size\": \"1\",\n
-        \"md5Hash\": \"xMpCOKC5I4INzFCab3WEmw==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?generation=1488574129510430&alt=media\",\n
-        \"crc32c\": \"kPWZ4w==\",\n \"etag\": \"CJ6w2OGau9ICEAE=\"\n}\n"}
+        \"1489515839025596\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2017-03-14T18:23:58.988Z\",\n
+        \"updated\": \"2017-03-14T18:23:58.988Z\",\n \"storageClass\": \"STANDARD\",\n
+        \"timeStorageClassUpdated\": \"2017-03-14T18:23:58.988Z\",\n \"size\": \"1\",\n
+        \"md5Hash\": \"xMpCOKC5I4INzFCab3WEmw==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?generation=1489515839025596&alt=media\",\n
+        \"crc32c\": \"kPWZ4w==\",\n \"etag\": \"CLzj4/PO1tICEAE=\"\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Length: ['681']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:49 GMT']
-      ETag: [CJ6w2OGau9ICEAE=]
+      Date: ['Tue, 14 Mar 2017 18:23:59 GMT']
+      ETag: [CLzj4/PO1tICEAE=]
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uoh3QzqyY3yg_AnkFCTewARKhU3mPAhTUBGxfZoN9agRRS9i1IyVPReKnzC_TZ9MEqo4yRuOIkffwzdP5eiXU1LKc2xxg]
+      X-GUploader-UploadID: [AEnB2Uob0kFL7ZOtHIXYJsiCLDSDcNOCMKYgRwYk9zh6u2jr-p-vTuV-nZhP8vDknV8WpuHpIlMlCQ1Fxawxlo8-2OLDeXA6Rw]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -224,25 +224,25 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
   response:
     body: {string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
-        \"storage#object\",\n   \"id\": \"gcsfs-testing/mapping/x/1488574129510430\",\n
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/mapping/x/1489515839025596\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/mapping%2Fx\",\n
         \  \"name\": \"mapping/x\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1488574129510430\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2017-03-03T20:48:49.489Z\",\n   \"updated\": \"2017-03-03T20:48:49.489Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2017-03-03T20:48:49.489Z\",\n
+        \"1489515839025596\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2017-03-14T18:23:58.988Z\",\n   \"updated\": \"2017-03-14T18:23:58.988Z\",\n
+        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2017-03-14T18:23:58.988Z\",\n
         \  \"size\": \"1\",\n   \"md5Hash\": \"xMpCOKC5I4INzFCab3WEmw==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?generation=1488574129510430&alt=media\",\n
-        \  \"crc32c\": \"kPWZ4w==\",\n   \"etag\": \"CJ6w2OGau9ICEAE=\"\n  }\n ]\n}\n"}
+        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?generation=1489515839025596&alt=media\",\n
+        \  \"crc32c\": \"kPWZ4w==\",\n   \"etag\": \"CLzj4/PO1tICEAE=\"\n  }\n ]\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0, must-revalidate, no-transform']
       Content-Length: ['764']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:48:49 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:48:49 GMT']
+      Date: ['Tue, 14 Mar 2017 18:23:59 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:23:59 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uq5b0YKr71CjE1US-FkKRIx_NRp5zXasTvmmF8bys45RhFGD7J_gCntsCGWlQ1ejejGNVXjIphzEZi070eoPHinrhvGlg]
+      X-GUploader-UploadID: [AEnB2Uqr9GNEe8q8i0Gfz8lf0wisirv81FIHG2jgXEH4YlTJ3phd7qGGo_BnqHV6wTwC453UHIZJwZICLNSlcijv0IsCNtj_bg]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -253,24 +253,24 @@ interactions:
       Range: [bytes=0-5242880]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?alt=media&generation=1488574129510430
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?alt=media&generation=1489515839025596
   response:
     body: {string: '1'}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Disposition: [attachment]
       Content-Length: ['1']
       Content-Range: [bytes 0-0/1]
       Content-Type: [application/octet-stream]
-      Date: ['Fri, 03 Mar 2017 20:48:50 GMT']
-      ETag: [CJ6w2OGau9ICEAE=]
+      Date: ['Tue, 14 Mar 2017 18:23:59 GMT']
+      ETag: [CLzj4/PO1tICEAE=]
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Urkkyag40WQVZiSSshCDbGB-KVKTc0X5tPWxDixFMgeDwNy8lKIHW-xiA1NtWqav2F9ctJBZk_NTL1kL2ABGrazJhVG0A]
-      X-Goog-Generation: ['1488574129510430']
+      X-GUploader-UploadID: [AEnB2UpAdsDsUW5VSLPf5UDGFO7pVBV1nX0_m_-PUF1t1mJzgNYJreXfouiG3u8XGeov3Mfk8-gHm8huMtLkpOx_UmGiKy5ckg]
+      X-Goog-Generation: ['1489515839025596']
       X-Goog-Hash: [crc32c=kPWZ4w==]
       X-Goog-Metageneration: ['1']
       X-Goog-Storage-Class: [STANDARD]
@@ -281,27 +281,57 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.13.0]
+    method: POST
+    uri: https://www.googleapis.com/oauth2/v4/token?grant_type=refresh_token
+  response:
+    body:
+      string: !!binary |
+        H4sIAEA1yFgC/6tWSkxOTi0uji/Jz07NU7JSUKqoqFDSUVAC8+NLKgtSQYJOqYlFqUUg8dSKgsyi
+        1OL4TJBiYzMDA6BYZgqq9loA0rtzTlYAAAA=
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Tue, 14 Mar 2017 18:24:00 GMT']
+      Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [GSE]
+      Transfer-Encoding: [chunked]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
       Range: [bytes=0-5242880]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?alt=media&generation=1488574129510430
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/mapping%2Fx?alt=media&generation=1489515839025596
   response:
     body: {string: '1'}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Disposition: [attachment]
       Content-Length: ['1']
       Content-Range: [bytes 0-0/1]
       Content-Type: [application/octet-stream]
-      Date: ['Fri, 03 Mar 2017 20:48:50 GMT']
-      ETag: [CJ6w2OGau9ICEAE=]
+      Date: ['Tue, 14 Mar 2017 18:24:00 GMT']
+      ETag: [CLzj4/PO1tICEAE=]
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UrjZ2ybLQUHKLOmDTjjz_csCBIcNFSb7nFkOClU-qH7H7wTGGabBdFnC8mZwdjfczBcOIocoSz6ixiGt-Km4cFBd6F9VQ]
-      X-Goog-Generation: ['1488574129510430']
+      X-GUploader-UploadID: [AEnB2Ur6lTnqLLT68W4MTtGDC1UP0f57Rpc1x8kYzBpHYBNZLX8DvXc-obVTipvhXN7decdXesmV78O9u7qFXOmzv3hdoU1Evw]
+      X-Goog-Generation: ['1489515839025596']
       X-Goog-Hash: [crc32c=kPWZ4w==]
       X-Goog-Metageneration: ['1']
       X-Goog-Storage-Class: [STANDARD]
@@ -319,15 +349,15 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Length: ['0']
       Content-Type: [application/json]
-      Date: ['Fri, 03 Mar 2017 20:48:50 GMT']
+      Date: ['Tue, 14 Mar 2017 18:24:00 GMT']
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uo3qR291T8CVlBMrOeTf6X3dml6QN22hYak8lIsoRKr0w-7t8-dG5Piinlle2USQtZLZrEAGBmuJVSqppPnoMKMEfjs2g]
+      X-GUploader-UploadID: [AEnB2UqAbY_k9pZgV9xUpvGBF8zWve8CEPKuaWT4hdSu_DIFQ-a3okCqbOOywHiXdl-8bI6YqKzpwJnoubq_3LeLdBdZoX2wDA]
     status: {code: 204, message: No Content}
 version: 1

--- a/gcsfs/tests/recordings/test_pickle.yaml
+++ b/gcsfs/tests/recordings/test_pickle.yaml
@@ -12,14 +12,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAMrVuVgC/6tWSq0oyCxKLY7PzFOyUjA2MzDQUVDKTIkvyc9OBYkoVVRUKAGFwPz4ksqCVJCg
-        U2piUWoRSDwxOTm1uBhVeS0A03RPm1YAAAA=
+        H4sIAKg1yFgC/6tWSq0oyCxKLY7PzFOyUjA2MzDQUVAqyc9OzYsvqSxIBYopOaUmFqUWKQHFM1Pi
+        wVIg0YqKCpBQYnJyanExqnAtANQg8/VWAAAA
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:58 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:44 GMT']
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [GSE]
@@ -71,15 +71,15 @@ interactions:
         \  \"metageneration\": \"1\",\n   \"location\": \"US\",\n   \"storageClass\":
         \"STANDARD\",\n   \"etag\": \"CAE=\"\n  }\n ]\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0, must-revalidate, no-transform']
       Content-Length: ['2440']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:58 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:58 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:44 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:44 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UoPYKDcWK7xbNbFblVoxAO-ansi7NiTrPdWwxQ-EEWPXnMBa5YuyRWQ0kB1zz2YzLhvIKb2Es6JKsXAB08pgwb5O8WlzQ]
+      X-GUploader-UploadID: [AEnB2Uq7H9y0eV5ktqiyCd4tIM0UvLW6auX4_GPIytbtPe5Jc_jFokHXlHPOWQXL731sxr8rJCaSmAcZpAudtTyCKR9LMIFacA]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -96,15 +96,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:58 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:58 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:45 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:45 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UrcepeOovWf37pr2XO3LOA2p0I5L-dFiTsQ4n8cVHtQdJMy9wsRggabCdjHTq8RER7ABOnyIsbOsyR_17d7Qkk5ecBpgw]
+      X-GUploader-UploadID: [AEnB2Ur9-iBFWpjlJUQ2-cq4PEcGvVY-OzM3BcAScN_pJmh_Y4u_MVYcUMDGJ81fmVusZZbo7T0VbbKtcsXCzRCgYW2xUBuQWQ]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -121,15 +121,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:58 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:58 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:45 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:45 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uph_5SXeDVHiuHIJcJZFSfaVO6h3qh96om8BwGxBWli1Fek5e9xRmpWwRLo0Jkgx9JvKwVSAj-wIBJF8c2OO_ftBmU_Gw]
+      X-GUploader-UploadID: [AEnB2Up1xnZkG4FJ4_g3Wgfe4LhIA_k1IVCDPVomr9hQaaRXyNPMb_i0zsOhjEt2ZWUcI8yomovOLPK5FwQ19CVtsmxwPShFlA]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -146,15 +146,15 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:59 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:59 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:45 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:45 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UqkkcveaVpP2pbgLj-tVPt76oXWY49BCQx_daqPi3YOvUc7hvQvzWkjkzyUWsYyiLOBRJORG2ybzFptZcxnDRFKB7E77w]
+      X-GUploader-UploadID: [AEnB2Up1dSTfH5Dd-8GlQWCQkZ_YZjQmzDE_fX-EAGGkngSkAoBUN1uWFhupfTnLbuLL8GBgOmd9lT0trVR9ziCNlTN-T8vQcA]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -171,16 +171,46 @@ interactions:
         \   \"reason\": \"notFound\",\n    \"message\": \"Not Found\"\n   }\n  ],\n
         \ \"code\": 404,\n  \"message\": \"Not Found\"\n }\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0']
       Content-Length: ['165']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:59 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:59 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:45 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:45 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Uq-wCD9BNzvhc-ySProJQVEVmR49NRZBnW2Oz6MV8bpnYvFTp8WnSoxeYtsE0G5lU-Lr9GJRZNS72IgZF8NsLzm-nbVGw]
+      X-GUploader-UploadID: [AEnB2Uqd5V_1GnWma4KJTcLdP7TrFk3W1qUI4IngXnmykgyPS06knKvn9bSjkZV8ZDVlJlcH8yxg5AfZShMXRxhA8WjF8EZ1Kg]
     status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.13.0]
+    method: POST
+    uri: https://www.googleapis.com/oauth2/v4/token?grant_type=refresh_token
+  response:
+    body:
+      string: !!binary |
+        H4sIAKo1yFgC/6tWSq0oyCxKLY7PzFOyUjA2MzDQUVAqyc9OzYsvqSxIBYopOaUmFqUWKQHFM1Pi
+        wVIg0YqKCpBQYnJyanExqnAtANQg8/VWAAAA
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Tue, 14 Mar 2017 18:25:46 GMT']
+      Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [GSE]
+      Transfer-Encoding: [chunked]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
 - request:
     body: null
     headers:
@@ -192,26 +222,26 @@ interactions:
     method: POST
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?name=tmp%2Ftest%2Fa&uploadType=media
   response:
-    body: {string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/tmp/test/a/1488573899476577\",\n
+    body: {string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/tmp/test/a/1489515946298786\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa\",\n
         \"name\": \"tmp/test/a\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1488573899476577\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2017-03-03T20:44:59.462Z\",\n
-        \"updated\": \"2017-03-03T20:44:59.462Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2017-03-03T20:44:59.462Z\",\n \"size\": \"0\",\n
-        \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa?generation=1488573899476577&alt=media\",\n
-        \"crc32c\": \"AAAAAA==\",\n \"etag\": \"COGcgPSZu9ICEAE=\"\n}\n"}
+        \"1489515946298786\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2017-03-14T18:25:46.275Z\",\n
+        \"updated\": \"2017-03-14T18:25:46.275Z\",\n \"storageClass\": \"STANDARD\",\n
+        \"timeStorageClassUpdated\": \"2017-03-14T18:25:46.275Z\",\n \"size\": \"0\",\n
+        \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa?generation=1489515946298786&alt=media\",\n
+        \"crc32c\": \"AAAAAA==\",\n \"etag\": \"CKKb96bP1tICEAE=\"\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Length: ['689']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:59 GMT']
-      ETag: [COGcgPSZu9ICEAE=]
+      Date: ['Tue, 14 Mar 2017 18:25:46 GMT']
+      ETag: [CKKb96bP1tICEAE=]
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UreBsRXG5apF_ao8UFg2yur1KWrdWEbCGHXQVeXHtTh-ovhlHfM_Mo-sYgDRj9_BD89sg7xaabCRPMgqqB32bV3DZYw0ktDJjDpBmJeC_7Fx7oSgI4]
+      X-GUploader-UploadID: [AEnB2UrLnP7WCZVskWsUAfwD5a3LljljNOQQn51dMfGsRlHWynSb0ex5oIkfAymch2VFWjE0533m_eipLacH-KMHPeKXy3oxmg]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -224,25 +254,56 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
   response:
     body: {string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
-        \"storage#object\",\n   \"id\": \"gcsfs-testing/tmp/test/a/1488573899476577\",\n
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/tmp/test/a/1489515946298786\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa\",\n
         \  \"name\": \"tmp/test/a\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1488573899476577\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2017-03-03T20:44:59.462Z\",\n   \"updated\": \"2017-03-03T20:44:59.462Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2017-03-03T20:44:59.462Z\",\n
+        \"1489515946298786\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2017-03-14T18:25:46.275Z\",\n   \"updated\": \"2017-03-14T18:25:46.275Z\",\n
+        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2017-03-14T18:25:46.275Z\",\n
         \  \"size\": \"0\",\n   \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa?generation=1488573899476577&alt=media\",\n
-        \  \"crc32c\": \"AAAAAA==\",\n   \"etag\": \"COGcgPSZu9ICEAE=\"\n  }\n ]\n}\n"}
+        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa?generation=1489515946298786&alt=media\",\n
+        \  \"crc32c\": \"AAAAAA==\",\n   \"etag\": \"CKKb96bP1tICEAE=\"\n  }\n ]\n}\n"}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['private, max-age=0, must-revalidate, no-transform']
       Content-Length: ['772']
       Content-Type: [application/json; charset=UTF-8]
-      Date: ['Fri, 03 Mar 2017 20:44:59 GMT']
-      Expires: ['Fri, 03 Mar 2017 20:44:59 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:46 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:46 GMT']
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2Ur8U5a5ksINqqnYCTAsZzjDYkPpW_SxTFQugnGKWTPjdfE2ePV0uKoKkwwHIbCp4wFtpr48DfqKh8Ex5mWXEHFORymaMw]
+      X-GUploader-UploadID: [AEnB2UpYwYPYEEcV3Imu13QVNOrI08wHO256-wgNWa3YHPkIxAlXddQd7fqQuyI4f3kKhftwq1T_L6N3tqq5pPUbvdkaVqmYZw]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body: {string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/tmp/test/a/1489515946298786\",\n
+        \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa\",\n
+        \  \"name\": \"tmp/test/a\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
+        \"1489515946298786\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2017-03-14T18:25:46.275Z\",\n   \"updated\": \"2017-03-14T18:25:46.275Z\",\n
+        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2017-03-14T18:25:46.275Z\",\n
+        \  \"size\": \"0\",\n   \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n   \"mediaLink\":
+        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/tmp%2Ftest%2Fa?generation=1489515946298786&alt=media\",\n
+        \  \"crc32c\": \"AAAAAA==\",\n   \"etag\": \"CKKb96bP1tICEAE=\"\n  }\n ]\n}\n"}
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['private, max-age=0, must-revalidate, no-transform']
+      Content-Length: ['772']
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Tue, 14 Mar 2017 18:25:46 GMT']
+      Expires: ['Tue, 14 Mar 2017 18:25:46 GMT']
+      Server: [UploadServer]
+      Vary: [Origin, X-Origin]
+      X-GUploader-UploadID: [AEnB2UrP9KM9ArbW5rkFlhy3ZDmQo45GVolcyVYb2Ss-sRZwqaaxj9A9jOsCZZ1koiy61qm1CvsyChe4z7fOLUIsUUA34fOe7g]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -257,15 +318,15 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      Alt-Svc: ['quic=":443"; ma=2592000; v="36,35,34"']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
       Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
       Content-Length: ['0']
       Content-Type: [application/json]
-      Date: ['Fri, 03 Mar 2017 20:45:00 GMT']
+      Date: ['Tue, 14 Mar 2017 18:25:47 GMT']
       Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
       Pragma: [no-cache]
       Server: [UploadServer]
       Vary: [Origin, X-Origin]
-      X-GUploader-UploadID: [AEnB2UqUceQjK3b5uYyptvDRyoDoDoWeOurcGRQCmc0BsqnwLVQdJUtd-GL7DBz1V0Y-JluEXH8TV-PDKYfBtqs-V1IHmgMj3w]
+      X-GUploader-UploadID: [AEnB2Uokiz0-PLGXy1vx0XAFhAJj6-8AXdAbPDXc3ZjUNJb89ih4R8yBDB37Ga2T_RMu8vMk8gsVMEcQyZ4eY-49hEvPrjIbew]
     status: {code: 204, message: No Content}
 version: 1

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -75,8 +75,11 @@ def test_pickle(token_restore):
     with gcs_maker() as gcs:
         import pickle
         gcs2 = pickle.loads(pickle.dumps(gcs))
+
+        # *values* may be equal during tests
+        assert gcs.header is not gcs2.header
         gcs.touch(a)
-        assert gcs.ls(TEST_BUCKET) == gcs.ls(TEST_BUCKET)
+        assert gcs.ls(TEST_BUCKET) == gcs2.ls(TEST_BUCKET)
 
 
 @my_vcr.use_cassette(match=['all'])


### PR DESCRIPTION
Assumed use: that token= is passed a file which is in the same
location for each worker.

Note that the class attribute `tokens` will be loaded for each
process on startup (unless they are threads, in which case we
don't care).

Fixes #2 